### PR TITLE
Allow the service.js to shutdown cleanly 

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -34,7 +34,8 @@ module.exports = co.wrap(function*(name, no_setup) {
 
     let service = new Service({
         name: name || 'PM2',
-        script: path.join(__dirname, 'service.js')
+        script: path.join(__dirname, 'service.js'),
+		stopparentfirst: true
     });
 
     // Let this throw if we can't remove previous daemon


### PR DESCRIPTION
While using in windows server 2016, when i stoped the PM2 window service,  some of the node.exe proccess where still allive.
i added force killing to the pm2 proceess
