### PR TITLE
Catch shutdown message and force kill the pm2 proccess

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -92,3 +92,15 @@ function handle_error(err) {
         throw new Error(JSON.stringify(err));
     }
 }
+
+process.on('message', m => {
+	
+    if (m == 'shutdown') {
+		
+		console.log('force shutdown fix');
+		
+		pm2.killDaemon(function err() { 
+			console.log(err);
+		});
+    }
+});

--- a/src/service.js
+++ b/src/service.js
@@ -99,8 +99,10 @@ process.on('message', m => {
 		
 		console.log('force shutdown fix');
 		
-		pm2.killDaemon(function err() { 
-			console.log(err);
-		});
+	    	if (pm2) {
+			pm2.killDaemon(function(err, apps) { 
+				console.log(err, apps);
+			});
+		}
     }
 });


### PR DESCRIPTION
While using in windows server 2016, when i stoped the PM2 window service,  some of the node.exe proccess where still allive.
i added force killing to the pm2 proceess
