### PR TITLE
Updated for NodeJS LTS 10.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm2-windows-service",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Install PM2 as a service on windows",
   "main": "src/index.js",
   "bin": {

--- a/src/install.js
+++ b/src/install.js
@@ -18,7 +18,6 @@ module.exports = co.wrap(function*(name, no_setup) {
     common.check_platform();
 
     yield common.admin_warning();
-
     let setup_response = yield no_setup ? Promise.resolve({
         perform_setup: false
     }) : inquirer.prompt([{
@@ -27,7 +26,6 @@ module.exports = co.wrap(function*(name, no_setup) {
         message: 'Perform environment setup (recommended)?',
         default: true
     }]);
-
     if(setup_response.perform_setup) {
         yield setup();
     }

--- a/src/setup.js
+++ b/src/setup.js
@@ -7,7 +7,7 @@ const inquirer = require('inquirer'),
 module.exports = function() {
     return inquirer.prompt([{
         type: 'confirm',
-        name: 'SET_PM2_HOME',
+        name: 'SET_PM2_HOME2',
         message: 'Set PM2_HOME?'
     }, {
         // Offer to update PM2_HOME
@@ -16,11 +16,11 @@ module.exports = function() {
         message: 'PM2_HOME value (this path should be accessible to the service user and\nshould not contain any "user-context" variables [e.g. %APPDATA%]):',
         default: process.env.PM2_HOME || '',
         when(answers) {
-            return answers.SET_PM2_HOME;
+            return answers.SET_PM2_HOME2;
         }
     }, {
         type: 'confirm',
-        name: 'SET_PM2_SERVICE_SCRIPTS',
+        name: 'SET_PM2_SERVICE_SCRIPTS2',
         message: 'Set PM2_SERVICE_SCRIPTS (the list of start-up scripts for pm2)?'
     }, {
         // Set PM2_SERVICE_SCRIPTS up (optional)
@@ -29,11 +29,11 @@ module.exports = function() {
         message: 'Set the list of startup scripts/files (semi-colon separated json config\nfiles or js files)',
         default: process.env.PM2_SERVICE_SCRIPTS || '',
         when(answers) {
-            return answers.SET_PM2_SERVICE_SCRIPTS;
+            return answers.SET_PM2_SERVICE_SCRIPTS2;
         }
     }, {
         type: 'confirm',
-        name: 'SET_PM2_SERVICE_PM2_DIR',
+        name: 'SET_PM2_SERVICE_PM2_DIR2',
         message: 'Set PM2_SERVICE_PM2_DIR (the location of the global pm2 to use with the service)? [recommended]'
     }, {
         // Set PM2_SERVICE_PM2_DIR up, to support using global pm2 version (non-optional?)
@@ -42,7 +42,7 @@ module.exports = function() {
         message: 'Specify the directory containing the pm2 version to be used by the\nservice',
         default: process.env.PM2_SERVICE_PM2_DIR || common.guess_pm2_global_dir(),
         when(answers) {
-            return answers.SET_PM2_SERVICE_PM2_DIR;
+            return answers.SET_PM2_SERVICE_PM2_DIR2;
         }
     }]).then(do_setup);
 };


### PR DESCRIPTION
In order for the service install to work on Windows Server 2016 with NodeJS 10.13, I had to modify the inquirer "name" attributes inside the install script. Not entirely sure why that fixes it but I'm assuming the names are in use elsewhere which has become an issue.